### PR TITLE
nbsp replace font fallback bugfix

### DIFF
--- a/src/highlight.coffee
+++ b/src/highlight.coffee
@@ -15,7 +15,10 @@ escapeString = (string) ->
   string.replace /[&"'<>]/g, escapeChar
 
 escapeStringNbsp = (string) ->
-  string.replace /[&"'<> ]/g, escapeChar
+  tmp = string.replace(/[&"'<>]/g, escapeChar);
+  tmp = tmp.replace(/  /g, "&nbsp; ")
+  tmp = tmp.replace(/  /g, " &nbsp;")
+  tmp.replace(/^ | $/mg, "&nbsp;")
 
 pushScope = (scopeStack, scope, html) ->
   scopeStack.push(scope)


### PR DESCRIPTION
nbsp replace font fallback now do not affect the whole line.

When using space -> nbsp replacement font fallback with combining characters leads to the whole line switching to the fallback font.